### PR TITLE
Removed the _R_CHECK_FORCE_SUGGESTS check parameter

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,4 +48,3 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          _R_CHECK_FORCE_SUGGESTS_: false


### PR DESCRIPTION
rdt and rdtLite are now being loaded from drat.